### PR TITLE
Ensure contact import creates company directory

### DIFF
--- a/backend/src/services/WbotServices/ImportContactsService.ts
+++ b/backend/src/services/WbotServices/ImportContactsService.ts
@@ -1,0 +1,85 @@
+import * as Sentry from "@sentry/node";
+import GetDefaultWhatsApp from "../../helpers/GetDefaultWhatsApp";
+import { getWbot } from "../../libs/wbot";
+import Contact from "../../models/Contact";
+import logger from "../../utils/logger";
+import ShowBaileysService from "../BaileysServices/ShowBaileysService";
+import CreateContactService from "../ContactServices/CreateContactService";
+import { isString, isArray } from "lodash";
+import path from "path";
+import fs from "fs";
+
+const ImportContactsService = async (companyId?: number, whatsappId?: number): Promise<void> => {
+  const defaultWhatsapp = await GetDefaultWhatsApp(whatsappId, companyId);
+  const wbot = getWbot(defaultWhatsapp.id);
+
+  let phoneContacts;
+  const publicFolder = path.resolve(__dirname, "..", "..", "..", "public");
+  const companyFolderPath = path.join(publicFolder, `company${companyId}`);
+
+  try {
+    const contactsString = await ShowBaileysService(wbot.id);
+    phoneContacts = JSON.parse(JSON.stringify(contactsString.contacts));
+
+    await fs.promises.mkdir(companyFolderPath, { recursive: true });
+    const beforeFilePath = path.join(companyFolderPath, "contatos_antes.txt");
+    fs.writeFile(beforeFilePath, JSON.stringify(phoneContacts, null, 2), (err) => {
+      if (err) {
+        logger.error(`Failed to write contacts to file: ${err}`);
+        throw err;
+      }
+      // console.log('O arquivo contatos_antes.txt foi criado!');
+    });
+
+  } catch (err) {
+    Sentry.captureException(err);
+    logger.error(`Could not get whatsapp contacts from phone. Err: ${err}`);
+  }
+
+  await fs.promises.mkdir(companyFolderPath, { recursive: true });
+  const afterFilePath = path.join(companyFolderPath, "contatos_depois.txt");
+  fs.writeFile(afterFilePath, JSON.stringify(phoneContacts, null, 2), (err) => {
+    if (err) {
+      logger.error(`Failed to write contacts to file: ${err}`);
+      throw err;
+    }
+    // console.log('O arquivo contatos_depois.txt foi criado!');
+  });
+
+  const phoneContactsList = isString(phoneContacts)
+    ? JSON.parse(phoneContacts)
+    : phoneContacts;
+
+  if (isArray(phoneContactsList)) {
+    phoneContactsList.forEach(async ({ id, name, notify }) => {
+      if (id === "status@broadcast" || id.includes("g.us")) return;
+      const number = id.replace(/\D/g, "");
+
+      const existingContact = await Contact.findOne({
+        where: { number, companyId }
+      });
+
+      if (existingContact) {
+        // Atualiza o nome do contato existente
+        existingContact.name = name || notify;
+        await existingContact.save();
+      } else {
+        // Criar um novo contato
+        try {
+          await CreateContactService({
+            number,
+            name: name || notify,
+            companyId
+          });
+        } catch (error) {
+          Sentry.captureException(error);
+          logger.warn(
+            `Could not get whatsapp contacts from phone. Err: ${error}`
+          );
+        }
+      }
+    });
+  }
+};
+
+export default ImportContactsService;


### PR DESCRIPTION
## Summary
- ensure the ImportContactsService creates the company-specific public folder before saving exported contacts

## Testing
- not run (environment does not provide WhatsApp integration to exercise the import flow)


------
https://chatgpt.com/codex/tasks/task_e_68d1bf857c88833089b3bbbacdfcf200