### PR TITLE
Add error handling for contact import file writes

### DIFF
--- a/backend/src/services/WbotServices/ImportContactsService.ts
+++ b/backend/src/services/WbotServices/ImportContactsService.ts
@@ -1,0 +1,85 @@
+import * as Sentry from "@sentry/node";
+import GetDefaultWhatsApp from "../../helpers/GetDefaultWhatsApp";
+import { getWbot } from "../../libs/wbot";
+import Contact from "../../models/Contact";
+import logger from "../../utils/logger";
+import ShowBaileysService from "../BaileysServices/ShowBaileysService";
+import CreateContactService from "../ContactServices/CreateContactService";
+import { isString, isArray } from "lodash";
+import path from "path";
+import fs from "fs";
+
+const ImportContactsService = async (companyId?: number, whatsappId?: number): Promise<void> => {
+  const defaultWhatsapp = await GetDefaultWhatsApp(whatsappId, companyId);
+  const wbot = getWbot(defaultWhatsapp.id);
+
+  let phoneContacts;
+  const publicFolder = path.resolve(__dirname, "..", "..", "..", "public");
+  const beforeFilePath = path.join(publicFolder, `company${companyId}`, "contatos_antes.txt");
+  const afterFilePath = path.join(publicFolder, `company${companyId}`, "contatos_depois.txt");
+
+  try {
+    const contactsString = await ShowBaileysService(wbot.id);
+    phoneContacts = JSON.parse(JSON.stringify(contactsString.contacts));
+    try {
+      await fs.promises.writeFile(
+        beforeFilePath,
+        JSON.stringify(phoneContacts, null, 2)
+      );
+    } catch (error) {
+      logger.error(`Failed to write contacts before import: ${error}`);
+      return;
+    }
+
+  } catch (err) {
+    Sentry.captureException(err);
+    logger.error(`Could not get whatsapp contacts from phone. Err: ${err}`);
+  }
+
+  try {
+    await fs.promises.writeFile(
+      afterFilePath,
+      JSON.stringify(phoneContacts, null, 2)
+    );
+  } catch (error) {
+    logger.error(`Failed to write contacts after import: ${error}`);
+    return;
+  }
+
+  const phoneContactsList = isString(phoneContacts)
+    ? JSON.parse(phoneContacts)
+    : phoneContacts;
+
+  if (isArray(phoneContactsList)) {
+    phoneContactsList.forEach(async ({ id, name, notify }) => {
+      if (id === "status@broadcast" || id.includes("g.us")) return;
+      const number = id.replace(/\D/g, "");
+
+      const existingContact = await Contact.findOne({
+        where: { number, companyId }
+      });
+
+      if (existingContact) {
+        // Atualiza o nome do contato existente
+        existingContact.name = name || notify;
+        await existingContact.save();
+      } else {
+        // Criar um novo contato
+        try {
+          await CreateContactService({
+            number,
+            name: name || notify,
+            companyId
+          });
+        } catch (error) {
+          Sentry.captureException(error);
+          logger.warn(
+            `Could not get whatsapp contacts from phone. Err: ${error}`
+          );
+        }
+      }
+    });
+  }
+};
+
+export default ImportContactsService;

--- a/backend/src/services/WbotServices/__tests__/ImportContactsService.spec.ts
+++ b/backend/src/services/WbotServices/__tests__/ImportContactsService.spec.ts
@@ -1,0 +1,79 @@
+import fs from "fs";
+import ImportContactsService from "../ImportContactsService";
+import logger from "../../../utils/logger";
+
+jest.mock("../../../helpers/GetDefaultWhatsApp", () => ({
+  __esModule: true,
+  default: jest.fn().mockResolvedValue({ id: 123 })
+}));
+
+jest.mock("../../../libs/wbot", () => ({
+  getWbot: jest.fn().mockReturnValue({ id: 456 })
+}));
+
+jest.mock("../../BaileysServices/ShowBaileysService", () => ({
+  __esModule: true,
+  default: jest.fn().mockResolvedValue({
+    contacts: [
+      { id: "123@s.whatsapp.net", name: "Test User", notify: "Test Notify" }
+    ]
+  })
+}));
+
+jest.mock("../../../models/Contact", () => ({
+  __esModule: true,
+  default: {
+    findOne: jest.fn().mockResolvedValue(null)
+  }
+}));
+
+jest.mock("../../ContactServices/CreateContactService", () => ({
+  __esModule: true,
+  default: jest.fn().mockResolvedValue(undefined)
+}));
+
+jest.mock("../../../utils/logger", () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+    warn: jest.fn()
+  }
+}));
+
+describe("ImportContactsService", () => {
+  const writeFileSpy = jest.spyOn(fs.promises, "writeFile");
+  const loggerErrorMock = logger.error as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    writeFileSpy.mockReset();
+    writeFileSpy.mockResolvedValue(undefined);
+  });
+
+  afterAll(() => {
+    writeFileSpy.mockRestore();
+  });
+
+  it("logs an error and aborts when it cannot write the before snapshot", async () => {
+    writeFileSpy.mockRejectedValueOnce(new Error("EACCES"));
+
+    await expect(ImportContactsService(1, 1)).resolves.toBeUndefined();
+
+    expect(writeFileSpy).toHaveBeenCalledTimes(1);
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to write contacts before import")
+    );
+  });
+
+  it("logs an error and aborts when it cannot write the after snapshot", async () => {
+    writeFileSpy.mockResolvedValueOnce(undefined);
+    writeFileSpy.mockRejectedValueOnce(new Error("EACCES"));
+
+    await expect(ImportContactsService(1, 1)).resolves.toBeUndefined();
+
+    expect(writeFileSpy).toHaveBeenCalledTimes(2);
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to write contacts after import")
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- replace callback-based writes in the WhatsApp contact import service with awaitable fs.promises.writeFile calls
- guard file writes with dedicated try/catch blocks that log controlled errors and abort processing
- add unit coverage that simulates permission errors and verifies graceful handling

## Testing
- npx jest --runInBand src/services/WbotServices/__tests__/ImportContactsService.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d1bfb21e648330a9cc8d0ace059f05